### PR TITLE
Changes for GCC 10

### DIFF
--- a/Inc/ADC_LL.h
+++ b/Inc/ADC_LL.h
@@ -38,9 +38,8 @@ typedef enum
 	mcuInternalTemp
 }_ADC_result;
 
-volatile uint16_t ADC_results[5], ADC_convertedResults[5], ADC_HighMin[3][2], ADC_conversionIndex, ADC_initialized;
-volatile uint16_t TS_CAL1, TS_CAL2;
-float intTempStep, temp30Cvoltage, HWmult[3];
+extern volatile uint16_t ADC_convertedResults[5];
+extern volatile uint16_t ADC_HighMin[3][2];
 
 void ADC_init(void);
 void ADC_deInit(void);

--- a/Inc/CAN_LL.h
+++ b/Inc/CAN_LL.h
@@ -20,8 +20,6 @@
 #ifndef CAN_LL_H_
 #define CAN_LL_H_
 
-uint16_t CAN_initialized;
-
 void CAN1_init(void);
 void CAN1_deInit(void);
 uint8_t CAN1_receive(uint32_t*, uint8_t *, uint8_t *);

--- a/Inc/IWDG_LL.h
+++ b/Inc/IWDG_LL.h
@@ -20,8 +20,6 @@
 #ifndef IWDG_LL_H_
 #define IWDG_LL_H_
 
-volatile uint16_t IWDG_initialized;
-
 void IWDG_init(void);
 
 void IWDG_start(void);

--- a/Inc/LTC6803_3_DD.h
+++ b/Inc/LTC6803_3_DD.h
@@ -22,7 +22,7 @@
 
 #include <stdint.h>
 
-struct LTC6803_3{
+typedef struct LTC_data_t {
 	uint8_t CFGR[6];				//LTC6803 configuration values
 	uint8_t Cells[18];				//raw LTC6803 cell measurement results
 	uint16_t cVoltages[12];			//mV, normal cell voltages
@@ -31,9 +31,7 @@ struct LTC6803_3{
 	uint16_t internalTemperature;	//Kelvin, internal temperature
 	uint8_t DIAG[2];
 	uint8_t PEC;
-} LTC_data;
-
-uint8_t SPI_message, SPI_index;
+} LTC_data_t;
 
 void LTC6803_init(void);
 

--- a/Inc/SPI_LL.h
+++ b/Inc/SPI_LL.h
@@ -23,8 +23,6 @@
 #define SET_CS_PIN	(GPIOA->BSRR |= (1 << 4))
 #define CLR_CS_PIN	(GPIOA->BSRR |= (1 << 20))
 
-uint16_t SPI_initialized;
-
 void SPI1_init(void);
 void SPI1_deInit(void);
 uint8_t SPI1_transmit(uint8_t *);

--- a/Inc/main.h
+++ b/Inc/main.h
@@ -138,7 +138,7 @@ typedef enum
 	active5vRequest
 }_5vRequest_ID;
 
-enum
+typedef enum
 {
 	notCharging = 0,
 	chargingStarting,

--- a/Inc/usb_device_ST.h
+++ b/Inc/usb_device_ST.h
@@ -32,7 +32,7 @@
 #include "stm32l4xx_hal.h"
 #include "usbd_def.h"
 
- USBD_HandleTypeDef hUsbDeviceFS;
+extern USBD_HandleTypeDef hUsbDeviceFS;
 /* USER CODE BEGIN INCLUDE */
 
 /* USER CODE END INCLUDE */

--- a/Src/ADC_LL.c
+++ b/Src/ADC_LL.c
@@ -24,6 +24,19 @@
 extern nonVolParameters nonVolPars;
 extern runtimeParameters runtimePars;
 
+volatile uint16_t ADC_results[5];
+volatile uint16_t ADC_convertedResults[5];
+volatile uint16_t ADC_HighMin[3][2];
+volatile uint16_t ADC_conversionIndex;
+volatile uint16_t ADC_initialized;
+
+volatile uint16_t TS_CAL1;
+volatile uint16_t TS_CAL2;
+
+float intTempStep;
+float temp30Cvoltage;
+float HWmult[3];
+
 void ADC_init(void){
 
 	if( ADC_initialized == 0 ){		//check that ADC is not initialized

--- a/Src/CAN_LL.c
+++ b/Src/CAN_LL.c
@@ -41,6 +41,8 @@ struct txBuffer_struct{
 static struct txBuffer_struct txBuffer[TX_BUFFER_SIZE];
 static uint8_t queueIndex = 0, txIndex = 0, ISR_running = 0;
 
+uint16_t CAN_initialized;
+
 extern nonVolParameters nonVolPars;
 extern runtimeParameters runtimePars;
 

--- a/Src/IWDG_LL.c
+++ b/Src/IWDG_LL.c
@@ -20,6 +20,8 @@
 #include "main.h"
 #include <IWDG_LL.h>
 
+volatile uint16_t IWDG_initialized;
+
 void IWDG_init(void){
 
 	if( IWDG_initialized == 0 ){		//check that IWDG is not initialized

--- a/Src/LTC6803_3_MD.c
+++ b/Src/LTC6803_3_MD.c
@@ -23,6 +23,8 @@
 #include <main.h>
 
 extern runtimeParameters runtimePars;
+LTC_data_t LTC_data;
+uint8_t SPI_message, SPI_index;
 
 void LTC6803_init(void){
 	LTC_data.CFGR[0] = 0xE1;

--- a/Src/SPI_LL.c
+++ b/Src/SPI_LL.c
@@ -20,6 +20,8 @@
 #include "stm32l4xx_hal.h"
 #include <SPI_LL.h>
 
+uint16_t SPI_initialized;
+
 void SPI1_init(){
 
 	if( SPI_initialized == 0 ){		//check that SPI is not initialized


### PR DESCRIPTION
This PR updates the code to work with GCC 10.

GCC 10 started enforcing single definitions for variables. Correcting this required moving the variable definitions to the .c file, and where needed, using an extern declaration in the header.

https://gcc.gnu.org/gcc-10/porting_to.html has more details.